### PR TITLE
Restore X sign flip on export to collada

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelColladaExporter.java
@@ -319,7 +319,7 @@ public class JointedModelColladaExporter {
     }
   }
 
-  private Source createFloatArraySourceFromInitializer(ListInitializer initializer, String name, int stride, double scale, boolean flipZ) {
+  private Source createFloatArraySourceFromInitializer(ListInitializer initializer, String name, int stride, double scale, boolean flipXandZ) {
 
     Source source = factory.createSource();
     source.setId(name);
@@ -330,14 +330,14 @@ public class JointedModelColladaExporter {
     List<Double> values = floatArray.getValue();
     initializer.initializeList(values);
 
-    //Flip Z as part of flipping the normals and positions from Alice space to Collada space
-    if (flipZ || scale != 1.0) {
+    //Flip X and Z as part of flipping the normals and positions from Alice space to Collada space
+    if (flipXandZ || scale != 1.0) {
       //Combine whether or not we're flipping with the scale value so we can do it all in one multiply
-      double flipScale = flipZ ? scale * -1.0 : scale;
+      double flipScale = flipXandZ ? scale * -1.0 : scale;
       for (int i = 0; i < values.size(); i += 3) {
-        values.set(i, values.get(i) * scale);
+        values.set(i, values.get(i) * flipScale); //Only flip X & Z
         values.set(i + 1, values.get(i + 1) * scale);
-        values.set(i + 2, values.get(i + 2) * flipScale); //Only flip Z
+        values.set(i + 2, values.get(i + 2) * flipScale); //Only flip X & Z
       }
     }
 
@@ -379,13 +379,13 @@ public class JointedModelColladaExporter {
       triangleList.add(BigInteger.valueOf(ib.get(i + 0))); //Normal 0
       triangleList.add(BigInteger.valueOf(ib.get(i + 0))); //UV 0
 
-      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //Position 2
-      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //Normal 2
-      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //UV 2
-
       triangleList.add(BigInteger.valueOf(ib.get(i + 1))); //Position 1
       triangleList.add(BigInteger.valueOf(ib.get(i + 1))); //Normal 1
       triangleList.add(BigInteger.valueOf(ib.get(i + 1))); //UV 1
+
+      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //Position 2
+      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //Normal 2
+      triangleList.add(BigInteger.valueOf(ib.get(i + 2))); //UV 2
     }
     triangles.setCount(BigInteger.valueOf(N / 3));
 


### PR DESCRIPTION
A reversion of (most of) commit:7376d9 "Flip models only along Z so they are imported correctly"

The intent of this change is to keep collada file consistent in their geometry and move responsibility for the conversion from collada to unity on to the unity code.

The counterpart of this is the player's branch feature/import_handedness.