### PR TITLE
New GLTF exporter material capabilities

### DIFF
--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -461,7 +461,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
 
     filteredBuffer.flip();
 
-    // Resize the buffer to just the valid entries.
+    // Resize the buffer to just the valid entries. JGTLF buffer operations assume limit() == capacity().
     return BufferUtilities.copyIntBuffer(filteredBuffer);
   }
 

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -207,6 +207,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
     gltf.setScene(sceneIndex);
 
     GltfAssetV2 gltfAsset = new GltfAssetV2(gltf, null);
+    resolveImages(tempDir, gltfAsset);
     resolveBuffers(bufferStructure, gltfAsset);
 
     return GltfModels.create(gltfAsset);

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -363,10 +363,12 @@ public class JointedModelGltfExporter implements JointedModelExporter {
 
   private MeshPrimitive createMeshPrimitive(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
     MeshPrimitive meshPrimitive = new MeshPrimitive();
-    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);
+    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);gt
 
     if (textureMaterialMap.containsKey(sgMesh.textureId.getValue())) {
       meshPrimitive.setMaterial(textureMaterialMap.get(sgMesh.textureId.getValue()));
+    } else {
+      System.out.println("Missing material for texture id " + sgMesh.textureId);
     }
 
     // Add the indices data from the mesh to the buffer structure

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -363,7 +363,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
 
   private MeshPrimitive createMeshPrimitive(edu.cmu.cs.dennisc.scenegraph.Mesh sgMesh, BufferStructureBuilder builder) {
     MeshPrimitive meshPrimitive = new MeshPrimitive();
-    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);gt
+    meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);
 
     if (textureMaterialMap.containsKey(sgMesh.textureId.getValue())) {
       meshPrimitive.setMaterial(textureMaterialMap.get(sgMesh.textureId.getValue()));

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -422,7 +422,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
     meshPrimitive.setMode(GltfConstants.GL_TRIANGLES);
 
     if (textureMaterialMap.containsKey(textureId)) {
-      meshPrimitive.setMaterial(textureId);
+      meshPrimitive.setMaterial(textureMaterialMap.get(textureId));
     } else {
       System.err.println("Missing material for texture id " + textureId);
     }

--- a/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
+++ b/core/model-loading/src/main/java/org/lgna/story/resourceutilities/JointedModelGltfExporter.java
@@ -461,7 +461,7 @@ public class JointedModelGltfExporter implements JointedModelExporter {
 
     filteredBuffer.flip();
 
-    // Resize the buffer to just the valid entries. JGTLF buffer operations assume limit() == capacity().
+    // Resize the buffer to just the valid entries. JGLTF buffer operations assume limit() == capacity().
     return BufferUtilities.copyIntBuffer(filteredBuffer);
   }
 


### PR DESCRIPTION
New GLTF Exporter capabilities:

- Activate alpha blending on materials if the base color texture has alpha
- Apply base color to materials
- Apply emissive factor to materials
- Apply opacity value to materials
- Export materials that don't have a base color texture
- Support meshes that bind multiple materials