### PR TITLE
Clear adapter element cache when program is stopped.

### DIFF
--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactory.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/AdapterFactory.java
@@ -292,4 +292,10 @@ public class AdapterFactory {
       s_elementToAdapterMap.remove(sgElement);
     }
   }
+
+  public static void forgetAllElements() {
+    synchronized (s_elementToAdapterMap) {
+      s_elementToAdapterMap.clear();
+    }
+  }
 }

--- a/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
+++ b/core/ide/src/main/java/org/alice/stageide/run/RunComposite.java
@@ -44,6 +44,7 @@ package org.alice.stageide.run;
 
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.render.OnscreenRenderTarget;
+import edu.cmu.cs.dennisc.render.gl.imp.adapters.AdapterFactory;
 import org.alice.ide.IDE;
 import org.alice.stageide.program.RunProgramContext;
 import org.alice.stageide.run.views.RunView;
@@ -161,6 +162,7 @@ public class RunComposite extends SimpleModalFrameComposite<RunView> {
     } else {
       Logger.warning(this);
     }
+    AdapterFactory.forgetAllElements();
   }
 
   private class RestartAction extends AbstractAction {


### PR DESCRIPTION
While debugging #302 I found the adapter factory has a cache that is not ever being cleared, and seems to not have much reused across runs, so this is a small change to clear it. More could be done