### PR TITLE
Roll back overly tight, and wrong,  generic use for nebulous models

### DIFF
--- a/core-nonfree/story-api-nonfree/src/main/java/org/lgna/story/implementation/sims2/NebulousVisualData.java
+++ b/core-nonfree/story-api-nonfree/src/main/java/org/lgna/story/implementation/sims2/NebulousVisualData.java
@@ -48,12 +48,12 @@ import edu.cmu.cs.dennisc.nebulous.Person;
 import edu.cmu.cs.dennisc.nebulous.Thing;
 import edu.cmu.cs.dennisc.scenegraph.*;
 import org.lgna.story.implementation.JointedModelImp;
-import org.lgna.story.resources.sims2.PersonResource;
+import org.lgna.story.resources.JointedModelResource;
 
 /**
  * @author Dennis Cosgrove
  */
-public class NebulousVisualData<M extends Model> implements JointedModelImp.VisualData<PersonResource> {
+public class NebulousVisualData<M extends Model> implements JointedModelImp.VisualData<JointedModelResource> {
   private final M nebModel;
   private final Visual[] sgVisuals = new Visual[] {new Visual()};
   private final SimpleAppearance[] sgAppearances = new SimpleAppearance[] {new SimpleAppearance()};
@@ -76,7 +76,7 @@ public class NebulousVisualData<M extends Model> implements JointedModelImp.Visu
   }
 
   @Override
-  public SkeletonVisual getSgVisualForExporting(PersonResource resource) {
+  public SkeletonVisual getSgVisualForExporting(JointedModelResource resource) {
     return nebModel.createSkeletonVisualForExporting(resource);
   }
 


### PR DESCRIPTION
The generics broke export of sims models that were not persons.