### PR TITLE
Feature/exec java

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,13 @@
+-Xmx1024m
+-Dswing.aatext=true
+-Xdock:name=Alice
+-Dcom.apple.mrj.application.apple.menu.about.name=Alice3
+-Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING
+-Dorg.alice.ide.internalTesting=true
+-Dorg.lgna.croquet.Element.isIdCheckDesired=true
+-Djogamp.gluegen.UseTempJarCache=false
+-Dorg.alice.stageide.isCrashDetectionDesired=false
+-Dsun.java2d.cmm=sun.java2d.cmm.kcms.KcmsServiceProvider
+--add-opens=java.desktop/sun.awt=ALL-UNNAMED
+--add-opens=java.base/java.io=ALL-UNNAMED
+--add-opens=java.base/java.time=ALL-UNNAMED

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,6 +1,5 @@
 -Xmx1024m
 -Dswing.aatext=true
--Xdock:name=Alice
 -Dcom.apple.mrj.application.apple.menu.about.name=Alice3
 -Dedu.cmu.cs.dennisc.java.util.logging.Logger.Level=WARNING
 -Dorg.alice.ide.internalTesting=true

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The working directory should be the root directory where you checked the Alice 3
 The VM options are:
 
     -ea
-    -splash:"./core/resources/target/distribution/application/SplashScreen.png"
+    -splash:"./installer/installerFiles/SplashScreen.png"
     -Xmx1024m
     -Dswing.aatext=true
     -Dorg.alice.ide.rootDirectory="./core/resources/target/distribution"

--- a/README.md
+++ b/README.md
@@ -33,34 +33,27 @@ To ensure the lfs files are available locally:
 
     git lfs pull 
 
-Compile and jar the Alice code.
+Compile the code, build the jars, and install them in the local mvn repository.
 
-    mvn compile
+    mvn -Dinstall4j.skip compile install
 
-or, to also build the NetBeans plugin:
+The install step will also build the NetBeans plugin in `{alice3}/netbeans/target/`
 
-    mvn -Dinstall4j.skip install
-
-And, if you want to use Install4J to build the installers:
+If you want to use Install4J to build the installers drop the skip flag:
 
         mvn install
 
-## Executing, testing, and building
+## Executing and testing
 
-After successfully compiling, you can launch the Alice IDE
+After successfully compiling and installing the Alice jars into the mvn repository, you can launch the Alice IDE
 
     cd alice-ide
-    mvn exec:java -Dentry-point
+    mvn exec:java -Dalice-ide
 
 Run unit tests
 
     cd ${alice3}
     mvn test
-
-Build the Alice installers, which  requires Install4J 7:
-
-    cd ${alice3}
-    mvn install
 
 ## IDE
 **IntelliJ IDEA** is suggested for coding/building Alice 3. There is a free community edition

--- a/alice-ide/pom.xml
+++ b/alice-ide/pom.xml
@@ -112,46 +112,18 @@
         <artifactId>exec-maven-plugin</artifactId>
         <executions>
           <execution>
-            <id>entry-point</id>
+            <id>alice-ide</id>
             <goals>
               <goal>java</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
-          <!-- systemProperties and mainClass are for exec:java only. They will not work with the exec goal, exec:exec -->
+          <!-- systemProperties and mainClass are for exec:java only. They will not work with exec:exec. -->
           <systemProperties>
-            <systemProperty>
-              <key>swing.aatext</key>
-              <value>true</value>
-            </systemProperty>
             <systemProperty>
               <key>org.alice.ide.rootDirectory</key>
               <value>../core/resources/target/distribution</value>
-            </systemProperty>
-            <systemProperty>
-              <key>com.apple.mrj.application.apple.menu.about.name</key>
-              <value>Alice3</value>
-            </systemProperty>
-            <systemProperty>
-              <key>edu.cmu.cs.dennisc.java.util.logging.Logger.Level</key>
-              <value>WARNING</value>
-            </systemProperty>
-            <systemProperty>
-              <key>org.alice.ide.internalTesting</key>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <key>org.lgna.croquet.Element.isIdCheckDesired</key>
-              <value>true</value>
-            </systemProperty>
-            <systemProperty>
-              <key>jogamp.gluegen.UseTempJarCache</key>
-              <value>false</value>
-            </systemProperty>
-            <systemProperty>
-              <key>org.alice.stageide.isCrashDetectionDesired</key>
-              <value>false</value>
             </systemProperty>
           </systemProperties>
           <mainClass>org.alice.stageide.EntryPoint</mainClass>

--- a/pom.xml
+++ b/pom.xml
@@ -457,23 +457,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.commonjava.maven.plugins</groupId>
-        <artifactId>directory-maven-plugin</artifactId>
-        <version>0.1</version>
-        <executions>
-          <execution>
-            <id>parent.path.property</id>
-            <goals>
-              <goal>highest-basedir</goal>
-            </goals>
-            <phase>initialize</phase>
-            <configuration>
-              <property>parent.basedir</property>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fix launching with `mvn exec:java -Dalice-ide`
mvn 3.3.1 adds use of project specific jvm.config files, so we will use it
The `-Dorg.alice.ide.rootDirectory` remains in the pom file where the relative location is correct. I found no permutation that worked in the top level jvm.config files.