### PR TITLE
Remove or disable VR loading checkbox

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/projecturi/MyProjectsTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/MyProjectsTab.java
@@ -55,6 +55,10 @@ public class MyProjectsTab extends DirectoryUriListTab {
     super(UUID.fromString("c7fb9c47-f215-47dc-941e-872842ce397e"), StageIDE.getActiveInstance().getProjectsDirectory());
   }
 
+  public boolean enableVrOption() {
+    return false;
+  }
+
   public void updateVrCheckbox() {
     updateVrCheckbox(getListSelectionState().getValue());
   }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/RecentProjectsTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/RecentProjectsTab.java
@@ -67,6 +67,11 @@ public class RecentProjectsTab extends ListUriTab {
   protected void refresh() {
   }
 
+  @Override
+  public boolean enableVrOption() {
+    return false;
+  }
+
   public void updateVrCheckbox() {
     updateVrCheckbox(getListSelectionState().getValue());
   }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/SelectUriTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/SelectUriTab.java
@@ -63,6 +63,15 @@ public abstract class SelectUriTab extends SimpleTabComposite<TabContentPanel> {
   public BooleanState isWorldVrReady() {
     return isWorldVrReadyState;
   }
+
+  public boolean showVrOption() {
+    return true;
+  }
+
+  public boolean enableVrOption() {
+    return true;
+  }
+
   public abstract UriProjectLoader getSelectedUri();
 
   protected abstract void refresh();
@@ -76,10 +85,13 @@ public abstract class SelectUriTab extends SimpleTabComposite<TabContentPanel> {
   }
 
   protected void updateVrCheckbox(ProjectSnapshot selected) {
+    if (!showVrOption()) {
+      return;
+    }
     if (isWorldVrReady().isEnabled()) {
       lastUserVrChoice = isWorldVrReadyState.getValue();
     }
-    isWorldVrReady().setEnabled(selected != null && !selected.isVrProject());
+    isWorldVrReady().setEnabled(enableVrOption() && selected != null && !selected.isVrProject());
     isWorldVrReady().setValueTransactionlessly(
         selected != null && selected.isVrProject() || lastUserVrChoice);
   }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/StartersTab.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/StartersTab.java
@@ -76,6 +76,12 @@ public class StartersTab extends ListUriTab {
   }
 
   @Override
+  public boolean showVrOption() {
+    // Starter worlds require a migration so this is disabled for now
+    return false;
+  }
+
+  @Override
   public ImmutableDataSingleSelectListState<ProjectSnapshot> getListSelectionState() {
     return this.listState;
   }

--- a/core/ide/src/main/java/org/alice/ide/projecturi/views/ListContentPanel.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/views/ListContentPanel.java
@@ -72,19 +72,20 @@ public class ListContentPanel extends TabContentPanel {
     scrollPane.setHorizontalScrollbarPolicy(ScrollPane.HorizontalScrollbarPolicy.NEVER);
     scrollPane.setVerticalScrollbarPolicy(ScrollPane.VerticalScrollbarPolicy.AS_NEEDED);
     this.addCenterComponent(scrollPane);
-    BooleanState isVr = tab.isWorldVrReady();
-
-    GridBagPanel pageEndPanel = new GridBagPanel();
-    GridBagConstraints gbc = new GridBagConstraints();
-    gbc.gridwidth = GridBagConstraints.REMAINDER;
-    gbc.fill = GridBagConstraints.HORIZONTAL;
-    gbc.weightx = 1.0;
-    pageEndPanel.addComponent(BoxUtilities.createVerticalSliver(4), gbc);
-    pageEndPanel.addComponent(Separator.createInstanceSeparatingTopFromBottom(), gbc);
-    pageEndPanel.addComponent(
-        new FlowPanel(FlowPanel.Alignment.CENTER, isVr.createCheckBox(), isVr.getSidekickLabel().createLabel()),
-        gbc);
-    addPageEndComponent(pageEndPanel);
+    if (tab.showVrOption()) {
+      BooleanState isVr = tab.isWorldVrReady();
+      GridBagPanel pageEndPanel = new GridBagPanel();
+      GridBagConstraints gbc = new GridBagConstraints();
+      gbc.gridwidth = GridBagConstraints.REMAINDER;
+      gbc.fill = GridBagConstraints.HORIZONTAL;
+      gbc.weightx = 1.0;
+      pageEndPanel.addComponent(BoxUtilities.createVerticalSliver(4), gbc);
+      pageEndPanel.addComponent(Separator.createInstanceSeparatingTopFromBottom(), gbc);
+      pageEndPanel.addComponent(
+          new FlowPanel(FlowPanel.Alignment.CENTER, isVr.createCheckBox(), isVr.getSidekickLabel().createLabel()),
+          gbc);
+      addPageEndComponent(pageEndPanel);
+    }
   }
 
   public List<ProjectSnapshot> getList() {


### PR DESCRIPTION
Removes check from Starters, which would require a migration.
Disables the check on My Projects and Recent Projects, but still updates it to reflect the state of the selected project.