### PR TITLE
Fix bug #756 and improve function sorting a bit

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
@@ -268,7 +268,6 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
       NamedUserType namedUserType = (NamedUserType) type;
 
       UserMethodsSubComposite userMethodsSubComposite = this.getUserMethodsSubComposite(namedUserType);
-      System.out.println("CHECK type: " + namedUserType.name + "  num methods: " + userMethodsSubComposite.getMethods().size());
       for (AbstractMethod method : userMethodsSubComposite.getMethods()) {
         methods.add(method);
       }

--- a/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
@@ -42,12 +42,11 @@
  *******************************************************************************/
 package org.alice.ide.member;
 
-import edu.cmu.cs.dennisc.java.util.Lists;
-
 import org.alice.ide.IDE;
 import org.alice.ide.declarationseditor.DeclarationComposite;
 import org.alice.ide.instancefactory.InstanceFactory;
 import org.alice.ide.member.views.MemberTabView;
+import org.alice.stageide.member.AddListenerProceduresComposite;
 
 import org.lgna.croquet.ImmutableDataSingleSelectListState;
 import org.lgna.croquet.event.ValueEvent;
@@ -62,10 +61,11 @@ import org.lgna.project.ast.JavaMethod;
 import org.lgna.project.ast.JavaType;
 import org.lgna.project.ast.NamedUserType;
 
-import javax.swing.JComponent;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * @author Dennis Cosgrove
@@ -141,7 +141,6 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
     }
   };
 
-  private final List<JComponent> jTitlesInNeedOfRepaintWhenInstanceFactoryChanges = Lists.newCopyOnWriteArrayList();
   private final AddMethodMenuModel addMethodMenuModel;
 
   public MemberTabComposite(UUID migrationId, AddMethodMenuModel addMethodMenuModel) {
@@ -194,37 +193,27 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
   }
 
   private List<MethodsSubComposite> getSubCompositesAlphabetically() {
-    List<AbstractMethod> methods = Lists.newLinkedList();
+    List<AbstractMethod> methods = new LinkedList<>();
     InstanceFactory instanceFactory = IDE.getActiveInstance().getDocumentFrame().getInstanceFactoryState().getValue();
     if (instanceFactory != null) {
       AbstractType<?, ?, ?> type = instanceFactory.getValueType();
       while (type != null) {
-        if (type instanceof NamedUserType) {
-          NamedUserType namedUserType = (NamedUserType) type;
-
-          UserMethodsSubComposite userMethodsSubComposite = this.getUserMethodsSubComposite(namedUserType);
-          for (AbstractMethod method : userMethodsSubComposite.getMethods()) {
-            if (this.isAcceptable(method)) {
-              if (isInclusionDesired(method)) {
-                methods.add(method);
-              }
-            }
-          }
-        } else if (type instanceof JavaType) {
-          for (AbstractMethod method : type.getDeclaredMethods()) {
-            if (this.isAcceptable(method)) {
-              if (isInclusionDesired(method)) {
-                methods.add(method);
-              }
-            }
-          }
-        }
+        methods.addAll(getAcceptableMethodsForType(type));
         type = type.isFollowToSuperClassDesired() ? type.getSuperType() : null;
       }
     }
+
     removeOverrides(methods);
 
-    List<MethodsSubComposite> subComposites = Lists.newLinkedList();
+    FilteredMethodsSubComposite listenersComposite = AddListenerProceduresComposite.getInstance();
+
+    if (!AddListenerProceduresComposite.isEventListenerTabActive()) {
+      methods = methods.stream()
+                       .filter(m -> !listenersComposite.isAcceptingOf(m))
+                       .collect(Collectors.toList());
+    }
+
+    List<MethodsSubComposite> subComposites = new LinkedList<>();
 
     if (!methods.isEmpty()) {
       UnclaimedMethodsComposite methodsComposite = this.getUnclaimedMethodsComposite();
@@ -235,8 +224,8 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
   }
 
   private List<MethodsSubComposite> getSubCompositesByCategory() {
-    List<MethodsSubComposite> subComposites = Lists.newLinkedList();
-    List<JavaMethod> javaMethods = Lists.newLinkedList();
+    List<MethodsSubComposite> subComposites = new LinkedList<>();
+    List<JavaMethod> javaMethods = new LinkedList<>();
 
     InstanceFactory instanceFactory = IDE.getActiveInstance().getDocumentFrame().getInstanceFactoryState().getValue();
     if (instanceFactory != null) {
@@ -247,14 +236,7 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
           UserMethodsSubComposite userMethodsSubComposite = this.getUserMethodsSubComposite(namedUserType);
           subComposites.add(userMethodsSubComposite);
         } else if (type instanceof JavaType) {
-          JavaType javaType = (JavaType) type;
-          for (JavaMethod javaMethod : javaType.getDeclaredMethods()) {
-            if (this.isAcceptable(javaMethod)) {
-              if (isInclusionDesired(javaMethod)) {
-                javaMethods.add(javaMethod);
-              }
-            }
-          }
+          javaMethods.addAll((List<JavaMethod>) getAcceptableMethodsForType(type));
         }
         type = type.isFollowToSuperClassDesired() ? type.getSuperType() : null;
       }
@@ -266,10 +248,10 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
     }
     addSubComposites(subComposites, javaMethods, getPotentialCategorySubComposites());
 
-    List<FilteredMethodsSubComposite> postSubComposites = Lists.newLinkedList();
+    List<FilteredMethodsSubComposite> postSubComposites = new LinkedList<>();
     addSubComposites(postSubComposites, javaMethods, getPotentialCategoryOrAlphabeticalSubComposites());
 
-    if (javaMethods.size() > 0) {
+    if (!javaMethods.isEmpty()) {
       UnclaimedMethodsComposite unclaimedMethodsComposite = this.getUnclaimedMethodsComposite();
       unclaimedMethodsComposite.sortAndSetMethods(javaMethods);
       subComposites.add(unclaimedMethodsComposite);
@@ -279,9 +261,31 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
     return subComposites;
   }
 
+  protected List<? extends AbstractMethod> getAcceptableMethodsForType(AbstractType<?, ?, ?> type) {
+    List<AbstractMethod> methods = new LinkedList<>();
+
+    if (type instanceof NamedUserType) {
+      NamedUserType namedUserType = (NamedUserType) type;
+
+      UserMethodsSubComposite userMethodsSubComposite = this.getUserMethodsSubComposite(namedUserType);
+      System.out.println("CHECK type: " + namedUserType.name + "  num methods: " + userMethodsSubComposite.getMethods().size());
+      for (AbstractMethod method : userMethodsSubComposite.getMethods()) {
+        methods.add(method);
+      }
+    } else if (type instanceof JavaType) {
+      for (AbstractMethod method : type.getDeclaredMethods()) {
+        methods.add(method);
+      }
+    }
+
+    return methods.stream()
+                  .filter(m -> isAcceptable(m) && isInclusionDesired(m))
+                  .collect(Collectors.toList());
+  }
+
   private <T extends FilteredMethodsSubComposite> void addSubComposites(List<? super FilteredMethodsSubComposite> subComposites, List<JavaMethod> javaMethods, List<T> potentialSubComposites) {
     for (T potentialSubComposite : potentialSubComposites) {
-      List<JavaMethod> acceptedMethods = Lists.newLinkedList();
+      List<JavaMethod> acceptedMethods = new LinkedList<>();
       ListIterator<JavaMethod> methodIterator = javaMethods.listIterator();
       while (methodIterator.hasNext()) {
         JavaMethod method = methodIterator.next();
@@ -291,7 +295,7 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
         }
       }
 
-      if (acceptedMethods.size() > 0) {
+      if (!acceptedMethods.isEmpty()) {
         potentialSubComposite.sortAndSetMethods(acceptedMethods);
         subComposites.add(potentialSubComposite);
       }

--- a/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/MemberTabComposite.java
@@ -43,10 +43,12 @@
 package org.alice.ide.member;
 
 import edu.cmu.cs.dennisc.java.util.Lists;
+
 import org.alice.ide.IDE;
 import org.alice.ide.declarationseditor.DeclarationComposite;
 import org.alice.ide.instancefactory.InstanceFactory;
 import org.alice.ide.member.views.MemberTabView;
+
 import org.lgna.croquet.ImmutableDataSingleSelectListState;
 import org.lgna.croquet.event.ValueEvent;
 import org.lgna.croquet.event.ValueListener;
@@ -197,11 +199,23 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
     if (instanceFactory != null) {
       AbstractType<?, ?, ?> type = instanceFactory.getValueType();
       while (type != null) {
-        type.getDeclaredMethods();
-        for (AbstractMethod method : type.getDeclaredMethods()) {
-          if (this.isAcceptable(method)) {
-            if (isInclusionDesired(method)) {
-              methods.add(method);
+        if (type instanceof NamedUserType) {
+          NamedUserType namedUserType = (NamedUserType) type;
+
+          UserMethodsSubComposite userMethodsSubComposite = this.getUserMethodsSubComposite(namedUserType);
+          for (AbstractMethod method : userMethodsSubComposite.getMethods()) {
+            if (this.isAcceptable(method)) {
+              if (isInclusionDesired(method)) {
+                methods.add(method);
+              }
+            }
+          }
+        } else if (type instanceof JavaType) {
+          for (AbstractMethod method : type.getDeclaredMethods()) {
+            if (this.isAcceptable(method)) {
+              if (isInclusionDesired(method)) {
+                methods.add(method);
+              }
             }
           }
         }
@@ -209,8 +223,10 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
       }
     }
     removeOverrides(methods);
+
     List<MethodsSubComposite> subComposites = Lists.newLinkedList();
-    if (methods.size() > 0) {
+
+    if (!methods.isEmpty()) {
       UnclaimedMethodsComposite methodsComposite = this.getUnclaimedMethodsComposite();
       methodsComposite.sortAndSetMethods(methods);
       subComposites.add(methodsComposite);
@@ -245,7 +261,7 @@ public abstract class MemberTabComposite<V extends MemberTabView> extends Member
     }
     removeOverrides(javaMethods);
 
-    if (subComposites.size() > 0) {
+    if (!subComposites.isEmpty()) {
       subComposites.add(SEPARATOR);
     }
     addSubComposites(subComposites, javaMethods, getPotentialCategorySubComposites());

--- a/core/ide/src/main/java/org/alice/ide/member/UnclaimedFunctionsComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/UnclaimedFunctionsComposite.java
@@ -42,12 +42,8 @@
  *******************************************************************************/
 package org.alice.ide.member;
 
-import org.alice.ide.croquet.models.ui.formatter.FormatterState;
-import org.alice.ide.formatter.Formatter;
-
 import org.lgna.project.ast.AbstractMethod;
 
-import java.util.Comparator;
 import java.util.UUID;
 
 /**
@@ -60,24 +56,6 @@ public class UnclaimedFunctionsComposite extends UnclaimedMethodsComposite {
 
   public static UnclaimedFunctionsComposite getInstance() {
     return SingletonHolder.instance;
-  }
-
-  private final Comparator<AbstractMethod> comparator = UnclaimedFunctionsComposite::compareMethodNames;
-
-  protected static int compareMethodNames(AbstractMethod methodA, AbstractMethod methodB) {
-    if (methodA == null) {
-      return methodB == null ? 0 : -1;
-    } else if (methodB == null) {
-      return 1;
-    }
-
-    Formatter formatter = FormatterState.getInstance().getValue();
-    return formatter.getNameForDeclaration(methodA).compareTo(formatter.getNameForDeclaration(methodB));
-  }
-
-  @Override
-  public Comparator<AbstractMethod> getComparator() {
-    return this.comparator;
   }
 
   private UnclaimedFunctionsComposite() {

--- a/core/ide/src/main/java/org/alice/ide/member/UnclaimedFunctionsComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/UnclaimedFunctionsComposite.java
@@ -42,8 +42,12 @@
  *******************************************************************************/
 package org.alice.ide.member;
 
+import org.alice.ide.croquet.models.ui.formatter.FormatterState;
+import org.alice.ide.formatter.Formatter;
+
 import org.lgna.project.ast.AbstractMethod;
 
+import java.util.Comparator;
 import java.util.UUID;
 
 /**
@@ -56,6 +60,24 @@ public class UnclaimedFunctionsComposite extends UnclaimedMethodsComposite {
 
   public static UnclaimedFunctionsComposite getInstance() {
     return SingletonHolder.instance;
+  }
+
+  private final Comparator<AbstractMethod> comparator = UnclaimedFunctionsComposite::compareMethodNames;
+
+  protected static int compareMethodNames(AbstractMethod methodA, AbstractMethod methodB) {
+    if (methodA == null) {
+      return methodB == null ? 0 : -1;
+    } else if (methodB == null) {
+      return 1;
+    }
+
+    Formatter formatter = FormatterState.getInstance().getValue();
+    return formatter.getNameForDeclaration(methodA).compareTo(formatter.getNameForDeclaration(methodB));
+  }
+
+  @Override
+  public Comparator<AbstractMethod> getComparator() {
+    return this.comparator;
   }
 
   private UnclaimedFunctionsComposite() {

--- a/core/ide/src/main/java/org/alice/ide/member/UnclaimedMethodsComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/UnclaimedMethodsComposite.java
@@ -42,6 +42,9 @@
  *******************************************************************************/
 package org.alice.ide.member;
 
+import org.alice.ide.croquet.models.ui.formatter.FormatterState;
+import org.alice.ide.formatter.Formatter;
+
 import org.lgna.project.ast.AbstractMethod;
 
 import java.util.Comparator;
@@ -51,7 +54,18 @@ import java.util.UUID;
  * @author Dennis Cosgrove
  */
 public abstract class UnclaimedMethodsComposite extends FilteredMethodsSubComposite {
-  private final Comparator<AbstractMethod> comparator = FilteredMethodsSubComposite::compareMethodNames;
+  private final Comparator<AbstractMethod> comparator = UnclaimedMethodsComposite::compareMethodNames;
+
+  protected static int compareMethodNames(AbstractMethod methodA, AbstractMethod methodB) {
+    if (methodA == null) {
+      return methodB == null ? 0 : -1;
+    } else if (methodB == null) {
+      return 1;
+    }
+
+    Formatter formatter = FormatterState.getInstance().getValue();
+    return formatter.getNameForDeclaration(methodA).compareTo(formatter.getNameForDeclaration(methodB));
+  }
 
   public UnclaimedMethodsComposite(UUID migrationId) {
     super(migrationId, true);

--- a/core/ide/src/main/java/org/alice/ide/member/UnclaimedMethodsComposite.java
+++ b/core/ide/src/main/java/org/alice/ide/member/UnclaimedMethodsComposite.java
@@ -44,7 +44,6 @@ package org.alice.ide.member;
 
 import org.alice.ide.croquet.models.ui.formatter.FormatterState;
 import org.alice.ide.formatter.Formatter;
-
 import org.lgna.project.ast.AbstractMethod;
 
 import java.util.Comparator;
@@ -54,15 +53,9 @@ import java.util.UUID;
  * @author Dennis Cosgrove
  */
 public abstract class UnclaimedMethodsComposite extends FilteredMethodsSubComposite {
-  private final Comparator<AbstractMethod> comparator = UnclaimedMethodsComposite::compareMethodNames;
+  private final Comparator<AbstractMethod> comparator = Comparator.nullsLast(UnclaimedMethodsComposite::compareMethodNames);
 
   protected static int compareMethodNames(AbstractMethod methodA, AbstractMethod methodB) {
-    if (methodA == null) {
-      return methodB == null ? 0 : -1;
-    } else if (methodB == null) {
-      return 1;
-    }
-
     Formatter formatter = FormatterState.getInstance().getValue();
     return formatter.getNameForDeclaration(methodA).compareTo(formatter.getNameForDeclaration(methodB));
   }

--- a/core/ide/src/main/java/org/alice/stageide/member/AddListenerProceduresComposite.java
+++ b/core/ide/src/main/java/org/alice/stageide/member/AddListenerProceduresComposite.java
@@ -70,25 +70,7 @@ public class AddListenerProceduresComposite extends FilteredMethodsSubComposite 
     return SingletonHolder.instance;
   }
 
-  private final Collection<String> names = Lists.newArrayList("addDefaultModelManipulation", "addObjectMoverFor");
-  private final Comparator<AbstractMethod> comparator = new Comparator<AbstractMethod>() {
-    @Override
-    public int compare(AbstractMethod methodA, AbstractMethod methodB) {
-      return compareMethodNames(methodA, methodB);
-    }
-  };
-
-  private AddListenerProceduresComposite() {
-    super(UUID.fromString("cfb5bd39-c07b-4436-a4e9-031dd25ca3b5"), true);
-  }
-
-  @Override
-  public Comparator<AbstractMethod> getComparator() {
-    return this.comparator;
-  }
-
-  @Override
-  public boolean isShowingDesired() {
+  public static boolean isEventListenerTabActive() {
     DeclarationsEditorComposite composite = IDE.getActiveInstance().getDocumentFrame().getDeclarationsEditorComposite();
     if (composite != null) {
       DeclarationTabState tabState = composite.getTabState();
@@ -109,6 +91,28 @@ public class AddListenerProceduresComposite extends FilteredMethodsSubComposite 
       }
     }
     return false;
+  }
+
+  private final Collection<String> names = Lists.newArrayList("addDefaultModelManipulation", "addObjectMoverFor");
+  private final Comparator<AbstractMethod> comparator = new Comparator<AbstractMethod>() {
+    @Override
+    public int compare(AbstractMethod methodA, AbstractMethod methodB) {
+      return compareMethodNames(methodA, methodB);
+    }
+  };
+
+  private AddListenerProceduresComposite() {
+    super(UUID.fromString("cfb5bd39-c07b-4436-a4e9-031dd25ca3b5"), true);
+  }
+
+  @Override
+  public Comparator<AbstractMethod> getComparator() {
+    return this.comparator;
+  }
+
+  @Override
+  public boolean isShowingDesired() {
+    return isEventListenerTabActive();
   }
 
   @Override


### PR DESCRIPTION
Avoid hiding property accessors under some groupings, sort functions by their display name instead of their Java name, and sort functions alphabetically under each return type