### PR TITLE
Fix binary operation LHS bug

### DIFF
--- a/core/croquet/src/main/java/org/lgna/croquet/CascadeRoot.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/CascadeRoot.java
@@ -142,7 +142,7 @@ public abstract class CascadeRoot<T, CM extends CompletionModel> extends Cascade
           public void menuKeyPressed(MenuKeyEvent e) {
             if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
               synchronized (popupMenu.getAwtComponent().getParent().getTreeLock()) {
-                popupMenu.setVisible(false);
+                popupMenu.getActivity().cancel();
               }
             }
           }

--- a/core/croquet/src/main/java/org/lgna/croquet/imp/cascade/RtRoot.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/imp/cascade/RtRoot.java
@@ -121,7 +121,9 @@ public class RtRoot<T, CM extends CompletionModel> extends RtBlankOwner<T[], T, 
 
       @Override
       public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
-        popupMenuCanceled(e);
+        if (menuItemContainer.getActivity().isCanceled()) {
+          popupMenuCanceled(e);
+        }
         RtRoot.this.removeAll(menuItemContainer);
       }
 

--- a/core/ide/src/main/java/org/alice/ide/cascade/ExpressionCascadeManager.java
+++ b/core/ide/src/main/java/org/alice/ide/cascade/ExpressionCascadeManager.java
@@ -163,10 +163,6 @@ public abstract class ExpressionCascadeManager {
   }
 
   public ExpressionCascadeContext popAndCheckContext(ExpressionCascadeContext expectedContext) {
-    if (this.contextStack.size() == 0) {
-      return NULL_CONTEXT;
-    }
-
     ExpressionCascadeContext poppedContext = this.popContext();
     if (poppedContext != expectedContext) {
       Logger.severe(poppedContext, expectedContext);


### PR DESCRIPTION
The keyboard navigation fix to clear menus properly when the escape key is pressed caused problems when building binary operations (AND, OR, plus, etc.) and possibly other menu results.
This changes the esc notification from making the menu invisible directly, to canceling the UserActivity.

This has two effects on the UI.
- First, fixing the bug, since the RtRoot will no longer look for mere invisibility and instead look for the activity. This also means the NULL_CONTEXT work around can be dropped from one place.
- Second, escape will cancel only a single menu most of the time. This might be useful in navigation, or it might be annoying for users. I think I like it, but please express an opinion when reviewing this.