### PR TITLE
Accept null expressions. Allows reading in of worlds with certain bugs.

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
+++ b/core/ast/src/main/java/org/lgna/project/ast/SourceCodeGenerator.java
@@ -427,7 +427,11 @@ public abstract class SourceCodeGenerator implements AstProcessor {
 
   @Override
   public void processExpression(Expression expression) {
-    expression.process(this);
+    if (expression == null) {
+      processNull();
+    } else {
+      expression.process(this);
+    }
   }
 
   @Override


### PR DESCRIPTION
This allows reading of worlds with null expressions.
The recent LHS bug is one way to create and write worlds with this issue.