### PR TITLE
Save the normalized vectors instead of creating them and using originals

### DIFF
--- a/core/story-api/src/main/java/org/alice/interact/MovementDirection.java
+++ b/core/story-api/src/main/java/org/alice/interact/MovementDirection.java
@@ -72,8 +72,7 @@ public enum MovementDirection {
   RESIZE(-1.0d, 1.0d, 0.0d);
 
   private MovementDirection(double x, double y, double z) {
-    this.directionVector = new Vector3(x, y, z);
-    this.directionVector.normalized();
+    this.directionVector = (new Vector3(x, y, z).normalized());
   }
 
   public Vector3 getVector() {


### PR DESCRIPTION
An error I introduced with the immutable math change.
These vectors are used to create orthogonal matrices, which are in turn not normalized.
So far it has led to no errors more severe than logging that the matrices are not normalized.