### PR TITLE
Drop unused code paths and don't log lack of drop site.

### DIFF
--- a/core/croquet/src/main/java/org/lgna/croquet/history/DragStep.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/history/DragStep.java
@@ -204,33 +204,20 @@ public class DragStep extends PrepStep<DragModel> {
     this.setLatestMouseEvent(e);
     DropReceptor nextDropReceptor = getDropReceptorUnder(e);
     if (this.currentDropReceptor != nextDropReceptor) {
-      if (this.currentPotentialDropSite != null) {
-        if (this.currentDropReceptor != null) {
-          //this.addChild( new ExitedPotentialDropSiteEvent( e, this.currentDropReceptor, this.currentPotentialDropSite ) );
-        }
-      }
       if (this.currentDropReceptor != null) {
         this.getModel().handleDragExitedDropReceptor(this);
         this.currentDropReceptor.dragExited(this, false);
-        //this.addChild( new ExitedDropReceptorEvent( e, this.currentDropReceptor ) );
       }
       this.currentDropReceptor = nextDropReceptor;
       if (this.currentDropReceptor != null) {
         this.currentDropReceptor.dragEntered(this);
         this.getModel().handleDragEnteredDropReceptor(this);
-        //this.addChild( new EnteredDropReceptorEvent( e, this.currentDropReceptor ) );
       }
     }
     if (this.currentDropReceptor != null) {
       DropSite nextPotentialDropSite = this.currentDropReceptor.dragUpdated(this);
       if (!Objects.equals(this.currentPotentialDropSite, nextPotentialDropSite)) {
-        if (this.currentPotentialDropSite != null) {
-          //this.addChild( new ExitedPotentialDropSiteEvent( e, this.currentDropReceptor, this.currentPotentialDropSite ) );
-        }
         this.currentPotentialDropSite = nextPotentialDropSite;
-        if (this.currentPotentialDropSite != null) {
-          //this.addChild( new EnteredPotentialDropSiteEvent( e, this.currentDropReceptor, this.currentPotentialDropSite ) );
-        }
       }
     }
 

--- a/core/croquet/src/main/java/org/lgna/croquet/triggers/DropTrigger.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/triggers/DropTrigger.java
@@ -64,9 +64,6 @@ public class DropTrigger extends AbstractMouseEventTrigger {
 
   private DropTrigger(UserActivity userActivity, ViewController<?, ?> viewController, MouseEvent e, DropSite dropSite) {
     super(userActivity, viewController, e);
-    if (dropSite == null) {
-      Logger.severe("drop site is null for", this);
-    }
     this.dropSite = dropSite;
   }
 


### PR DESCRIPTION
Removing some dead code and distracting logging.
Drops in the scene have a dropsite, but code drops do not so logging this every time is meaningless.