### PR TITLE
Store opening activity on Menu to use at end.

### DIFF
--- a/core/croquet/src/main/java/org/lgna/croquet/views/Menu.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/Menu.java
@@ -44,13 +44,14 @@
 package org.lgna.croquet.views;
 
 import org.lgna.croquet.AbstractMenuModel;
-import org.lgna.croquet.Application;
 import org.lgna.croquet.history.UserActivity;
 
 /**
  * @author Dennis Cosgrove
  */
 public class Menu extends AbstractMenu<AbstractMenuModel> {
+  private UserActivity activity;
+
   public Menu(AbstractMenuModel model) {
     super(model);
   }
@@ -81,7 +82,10 @@ public class Menu extends AbstractMenu<AbstractMenuModel> {
 
   @Override
   public UserActivity getActivity() {
-    // TODO Build menus with the root application or project activity and hold onto it?
-    return Application.getActiveInstance().getOpenActivity();
+    return activity;
+  }
+
+  public void setActivity(UserActivity activity) {
+    this.activity = activity;
   }
 }

--- a/core/croquet/src/main/java/org/lgna/croquet/views/PopupMenu.java
+++ b/core/croquet/src/main/java/org/lgna/croquet/views/PopupMenu.java
@@ -128,6 +128,7 @@ public class PopupMenu extends ViewController<JPopupMenu, PopupPrepModel> implem
   public void addMenu(Menu menu) {
     this.checkEventDispatchThread();
     this.getAwtComponent().add(menu.getAwtComponent());
+    menu.setActivity(userActivity);
   }
 
   @Override


### PR DESCRIPTION
Prevents null activity error that can crop up when menus close in unusual ways.
