### PR TITLE
Do not try to center camera on entire scene.

### DIFF
--- a/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/stageide/sceneeditor/StorytellingSceneEditor.java
@@ -435,7 +435,10 @@ public class StorytellingSceneEditor extends AbstractSceneEditor implements Rend
   }
 
   public void centerCameraOnSelectedField(UserActivity activity) {
-    mainCameraViewTracker.centerCameraOnField(activity, movableSceneCameraImp, getSelectedField());
+    UserField field = getSelectedField();
+    if (getActiveSceneField() != field) {
+      mainCameraViewTracker.centerCameraOnField(activity, movableSceneCameraImp, field);
+    }
   }
 
   @Override


### PR DESCRIPTION
Prevent double click from trying to focus on the scene