### PR TITLE
Fix/nbm build

### DIFF
--- a/alice-ide/pom.xml
+++ b/alice-ide/pom.xml
@@ -65,6 +65,11 @@
       <version>1.47.1</version>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.github.weisj/jsvg -->
+    <dependency>
+      <groupId>com.github.weisj</groupId>
+      <artifactId>jsvg</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.formdev</groupId>
       <artifactId>flatlaf</artifactId>

--- a/core/croquet/pom.xml
+++ b/core/croquet/pom.xml
@@ -69,6 +69,11 @@
       <artifactId>miglayout-swing</artifactId>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.github.weisj/jsvg -->
+    <dependency>
+      <groupId>com.github.weisj</groupId>
+      <artifactId>jsvg</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.formdev</groupId>
       <artifactId>flatlaf</artifactId>

--- a/core/croquet/pom.xml
+++ b/core/croquet/pom.xml
@@ -68,5 +68,46 @@
       <groupId>com.miglayout</groupId>
       <artifactId>miglayout-swing</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>no-natives</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <type>so</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>macos-arm64</classifier>
+      <type>dylib</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>macos-x86_64</classifier>
+      <type>dylib</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>windows-x86_64</classifier>
+      <type>dll</type>
+    </dependency>
+    <!-- Using other FlatLaf libraries, it is required to exclude "com.formdev:flatlaf" -->
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf-extras</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.formdev</groupId>
+          <artifactId>flatlaf</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,46 +29,6 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf</artifactId>
-      <classifier>no-natives</classifier>
-    </dependency>
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf</artifactId>
-      <classifier>linux-x86_64</classifier>
-      <type>so</type>
-    </dependency>
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf</artifactId>
-      <classifier>macos-arm64</classifier>
-      <type>dylib</type>
-    </dependency>
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf</artifactId>
-      <classifier>macos-x86_64</classifier>
-      <type>dylib</type>
-    </dependency>
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf</artifactId>
-      <classifier>windows-x86_64</classifier>
-      <type>dll</type>
-    </dependency>
-    <!-- Using other FlatLaf libraries, it is required to exclude "com.formdev:flatlaf" -->
-    <dependency>
-      <groupId>com.formdev</groupId>
-      <artifactId>flatlaf-extras</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.formdev</groupId>
-          <artifactId>flatlaf</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
 </project>

--- a/core/story-api/pom.xml
+++ b/core/story-api/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>imageio-webp</artifactId>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/com.github.weisj/jsvg -->
+    <dependency>
+      <groupId>com.github.weisj</groupId>
+      <artifactId>jsvg</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.formdev</groupId>
       <artifactId>flatlaf</artifactId>

--- a/core/story-api/pom.xml
+++ b/core/story-api/pom.xml
@@ -91,6 +91,47 @@
       <groupId>com.twelvemonkeys.imageio</groupId>
       <artifactId>imageio-webp</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>no-natives</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>linux-x86_64</classifier>
+      <type>so</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>macos-arm64</classifier>
+      <type>dylib</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>macos-x86_64</classifier>
+      <type>dylib</type>
+    </dependency>
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf</artifactId>
+      <classifier>windows-x86_64</classifier>
+      <type>dll</type>
+    </dependency>
+    <!-- Using other FlatLaf libraries, it is required to exclude "com.formdev:flatlaf" -->
+    <dependency>
+      <groupId>com.formdev</groupId>
+      <artifactId>flatlaf-extras</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.formdev</groupId>
+          <artifactId>flatlaf</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,12 @@
         <version>2.0.0</version>
       </dependency>
 
+      <!-- https://mvnrepository.com/artifact/com.github.weisj/jsvg -->
+      <dependency>
+        <groupId>com.github.weisj</groupId>
+        <artifactId>jsvg</artifactId>
+        <version>2.0.0</version>
+      </dependency>
       <!-- https://www.formdev.com/flatlaf/native-libraries/-->
       <dependency>
         <groupId>com.formdev</groupId>


### PR DESCRIPTION
Push flatlaf to only the packages that use it so the netbeans plugin can build without it.
Also added jsvg dependencies because without that in the modules the plugin does not use the plugin build fails. Strange, but apparently true.