### PR TITLE
Fix preview rendering

### DIFF
--- a/core/story-api/src/main/java/org/lgna/story/implementation/ProgramImp.java
+++ b/core/story-api/src/main/java/org/lgna/story/implementation/ProgramImp.java
@@ -378,8 +378,8 @@ public abstract class ProgramImp {
 
 
   public void shutDown() {
-    this.abstraction.setActiveScene(null);
     this.stopAnimator();
+    this.abstraction.setActiveScene(null);
     this.isProgramClosedExceptionDesired = true;
   }
 


### PR DESCRIPTION
Fix a bug where the world preview wouldn't resume rendering after running a world, if the world had been paused.

The order of setActiveScene() and stopAnimator() were originally changed to ensure everything was garbage collected properly after running a world in the editor, but this particular change no longer seems necessary for that.