### PR TITLE
Initialize rendering before passed in file is opened.

### DIFF
--- a/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
+++ b/alice-ide/src/main/java/org/alice/stageide/EntryPoint.java
@@ -52,7 +52,7 @@ import edu.cmu.cs.dennisc.java.lang.SystemUtilities;
 import edu.cmu.cs.dennisc.java.util.logging.Logger;
 import edu.cmu.cs.dennisc.javax.swing.UIManagerUtilities;
 import edu.cmu.cs.dennisc.javax.swing.WindowStack;
-import edu.cmu.cs.dennisc.render.gl.GlrRenderFactory;
+import edu.cmu.cs.dennisc.render.gl.RendererNativeLibraryLoader;
 import edu.wustl.lookingglass.utilities.memory.HeapWatchDog;
 import javafx.application.Application;
 import javafx.stage.Stage;
@@ -98,6 +98,9 @@ public class EntryPoint extends Application {
       Logger.severe("Was unable to set look and feel theme: " + updateFlatLafThemeException.getMessage());
       updateFlatLafThemeException.printStackTrace();
     }
+
+    // Initialize this on the main thread, before Swing or JavaFX, and before opening a project in args.
+    RendererNativeLibraryLoader.initializeIfNecessary();
 
     // Initialize Swing here to do it on the correct thread, outside of JavaFX
     SwingUtilities.invokeLater(() -> {
@@ -181,8 +184,6 @@ public class EntryPoint extends Application {
       ide.getDocumentFrame().getFrame().setVisible(true);
       heapMonitor = new HeapWatchDog();
     });
-    GlrRenderFactory.getInstance();
-
     // Call to initialize JavaFX
     launch(args);
   }


### PR DESCRIPTION
Move render initialization earlier to prevent locking up when opening a world on startup.

I closed this mistakenly. I have too many Alices and I accidentally switched file associations. This showed me that, yes, it was broken when I tried with an older version of Alice. Once corrected I also showed that the fix does work, as it had in every other test.