### PR TITLE
Make all project icons the same size in the Select Project window

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/projecturi/views/NotAvailableIcon.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/views/NotAvailableIcon.java
@@ -17,12 +17,12 @@ public class NotAvailableIcon implements Icon {
 
   @Override
   public int getIconWidth() {
-    return 160;
+    return SnapshotIcon.WIDTH;
   }
 
   @Override
   public int getIconHeight() {
-    return 120;
+    return SnapshotIcon.HEIGHT;
   }
 
   protected String getText() {

--- a/core/ide/src/main/java/org/alice/ide/projecturi/views/SnapshotIcon.java
+++ b/core/ide/src/main/java/org/alice/ide/projecturi/views/SnapshotIcon.java
@@ -51,8 +51,8 @@ import java.awt.Image;
  * @author Dennis Cosgrove
  */
 public class SnapshotIcon implements Icon {
-  private static final int WIDTH = 160;
-  private static final int HEIGHT = (WIDTH * 9) / 16;
+  public static final int WIDTH = 160;
+  public static final int HEIGHT = (WIDTH * 9) / 16;
   private final Image image;
 
   public SnapshotIcon(Image image) {


### PR DESCRIPTION
Make the null project icon the same size as the one with the project snapshot