### PR TITLE
Always use front and back face polygon mode to avoid render error on ARM

### DIFF
--- a/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSimpleAppearance.java
+++ b/core/glrender/src/main/java/edu/cmu/cs/dennisc/render/gl/imp/adapters/GlrSimpleAppearance.java
@@ -90,7 +90,7 @@ public class GlrSimpleAppearance<T extends SimpleAppearance> extends GlrAppearan
       }
     }
     rc.setColor(this.diffuse, this.opacity);
-    rc.gl.glPolygonMode(face, this.polygonMode);
+    rc.gl.glPolygonMode(GL_FRONT_AND_BACK, this.polygonMode);
     //todo
     if (this.isEthereal) {
       rc.gl.glDepthFunc(GL_LEQUAL);


### PR DESCRIPTION
This helps on Mac silicon and has no effect seen on other OSes or CPUs.