### PR TITLE
Drop false assertion. Classes besides Scene can have selectable fields.

### DIFF
--- a/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
+++ b/core/ide/src/main/java/org/alice/ide/sceneeditor/AbstractSceneEditor.java
@@ -239,7 +239,6 @@ public abstract class AbstractSceneEditor extends BorderPanel {
   }
 
   public void setSelectedField(UserType<?> declaringType, UserField field) {
-    assert (declaringType == this.getActiveSceneType()) || (field == this.getActiveSceneField());
     this.selectedField = field;
   }
 


### PR DESCRIPTION
If a class other than Scene has a field this assertion does not hold when the value is selected.