### PR TITLE
Only convert UserInstances to Java instances if the array is Java.

### DIFF
--- a/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
+++ b/core/ast/src/main/java/org/lgna/project/virtualmachine/VirtualMachine.java
@@ -399,13 +399,13 @@ public abstract class VirtualMachine {
   }
 
   public void setItemAtIndex(AbstractType<?, ?, ?> arrayType, Object array, Integer index, Object value) {
-    value = UserInstance.getJavaInstanceIfNecessary(value);
     assert arrayType != null;
     assert arrayType.isArray() : arrayType;
     if (array instanceof UserArrayInstance userArrayInstance) {
       this.checkIndex(index, userArrayInstance.getLength());
       userArrayInstance.set(index, value);
     } else {
+      value = UserInstance.getJavaInstanceIfNecessary(value);
       this.checkIndex(index, Array.getLength(array));
       Array.set(array, index, value);
     }


### PR DESCRIPTION
Without this fix values inserted into an Array are limited to Java classes.
Insert a Prop into an Array of Props and then try to use it and it has become an SProp, the superclass which is a Java class.